### PR TITLE
fixed saving the current profiles

### DIFF
--- a/qps/speclib/gui/spectralprofilesources.py
+++ b/qps/speclib/gui/spectralprofilesources.py
@@ -1765,6 +1765,7 @@ class SpectralProfileBridge(TreeModel):
             slw.setCurrentProfiles(features, currentProfileStyles=styles, make_permanent=add_permanent)
             if len(features) > 0:
                 results2[sid] = results2.get(sid, []) + features
+            self.mLastDestinations.add(sid)
         return results2
 
     def createFeatures(self,


### PR DESCRIPTION
fixed saving the current profiles when calling SpectralProfileBridge::addCurrentProfilesToSpeclib()

addresses https://github.com/EnMAP-Box/enmap-box/issues/871