### PR TITLE
fix SpectralProfileGeneratorNode::profiles() 

### DIFF
--- a/qps/speclib/gui/spectralprofilesources.py
+++ b/qps/speclib/gui/spectralprofilesources.py
@@ -1195,11 +1195,14 @@ class SpectralProfileGeneratorNode(FieldGeneratorNode):
         kwargs = copy.copy(kwargs)
         sampling: ProfileSamplingMode = self.sampling()
         kwargs['kernel_size'] = QSize(sampling.kernelSize())
-        profiles = self.mSourceNode.profileSource().collectProfiles(point, *args, **kwargs)
-        profiles = sampling.profiles(point, profiles)
-        profiles = self.mScalingNode.profiles(profiles)
-
-        return profiles
+        source: SpectralProfileSource = self.profileSource()
+        if isinstance(source, SpectralProfileSource):
+            profiles = source.collectProfiles(point, *args, **kwargs)
+            profiles = sampling.profiles(point, profiles)
+            profiles = self.mScalingNode.profiles(profiles)
+            return profiles
+        else:
+            return []
 
     def onChildNodeUpdate(self):
         """

--- a/qps/utils.py
+++ b/qps/utils.py
@@ -1834,7 +1834,7 @@ def parseWavelength(dataset) -> Tuple[np.ndarray, str]:
     if isinstance(dataset, gdal.Dataset):
         # 1. check on raster level
         for domain in sort_domains(dataset.GetMetadataDomainList()):
-            # see http://www.harrisgeospatial.com/docs/ENVIHeaderFiles.html for supported wavelength units
+            # see https://www.nv5geospatialsoftware.com/docs/enviheaderfiles.html for supported wavelength units
 
             mdDict = dataset.GetMetadata_Dict(domain)
 
@@ -1870,7 +1870,7 @@ def parseWavelength(dataset) -> Tuple[np.ndarray, str]:
             band: gdal.Band = dataset.GetRasterBand(b + 1)
             if b == 0:
                 for domain in sort_domains(band.GetMetadataDomainList()):
-                    # see http://www.harrisgeospatial.com/docs/ENVIHeaderFiles.html for supported wavelength units
+                    # see https://www.nv5geospatialsoftware.com/docs/enviheaderfiles.html for supported wavelength units
                     domainWL = domainWLU = None
 
                     mdDict = band.GetMetadata_Dict(domain)

--- a/tests/test_gdal_metadata.py
+++ b/tests/test_gdal_metadata.py
@@ -149,7 +149,7 @@ class TestsGdalMetadata(TestCaseBase):
         ds: gdal.Dataset = gdal.Open(path, gdal.GA_Update)
         ds.SetMetadataItem('bbl', """{
         0,
-        ; a comment to be excluded. See https://www.l3harrisgeospatial.com/docs/enviheaderfiles.html
+        ; a comment to be excluded. See https://www.nv5geospatialsoftware.com/docs/enviheaderfiles.html
         1,
         0}""", 'ENVI')
         ds.FlushCache()


### PR DESCRIPTION
SpectralProfileGeneratorNode::profiles()  returns empty list if no source is defined.